### PR TITLE
Fix invoice printing: hide prices in printer version

### DIFF
--- a/src/components/billing/CustomerBilling.tsx
+++ b/src/components/billing/CustomerBilling.tsx
@@ -509,7 +509,7 @@ export default function CustomerBilling() {
     // Ensure print_items is parsed (it might be stored as a JSON string)
     let editable = invoice as any;
     try {
-      const raw = (invoice as any).print_items ?? (invoice as any).print_items_json ?? null;
+      const raw = (invoice as any).print_items ?? (invoice as any).print_items_json ?? (invoice as any).items ?? (invoice as any).items_json ?? null;
       if (raw && typeof raw === 'string') {
         try { editable = { ...editable, print_items: JSON.parse(raw) }; } catch (e) { /* ignore parse error */ }
       } else if (raw && Array.isArray(raw)) {
@@ -518,6 +518,7 @@ export default function CustomerBilling() {
     } catch (e) {
       // ignore
     }
+    console.log('CustomerBilling: opening saved invoice for edit:', { invoice, editable });
     setEditingInvoice(editable as any);
     // Open the same modern print dialog for editing
   setSelectedContractsForInv(Array.isArray(invoice.contract_numbers) ? invoice.contract_numbers.map(String) : (invoice.contract_numbers ? String(invoice.contract_numbers).split(',').map(s=>s.trim()) : (invoice.contract_number ? [String(invoice.contract_number)] : [])));

--- a/src/components/billing/InvoiceTemplates.tsx
+++ b/src/components/billing/InvoiceTemplates.tsx
@@ -110,7 +110,7 @@ export const generateModernPrintInvoiceHTML = (data: ModernPrintInvoiceData): st
 
       <div class="customer-info">
         <div style="display:flex;justify-content:space-between;align-items:center;gap:8px;">
-          <div><strong>العميل:</strong> ${data.customerName || ''}</div>
+          <div><strong>العم��ل:</strong> ${data.customerName || ''}</div>
           <div style="direction:ltr">التاريخ: ${new Date(data.invoiceDate).toLocaleDateString('ar-LY')}</div>
         </div>
       </div>
@@ -124,7 +124,6 @@ export const generateModernPrintInvoiceHTML = (data: ModernPrintInvoiceData): st
             <th>إجمالي الأوجه</th>
             <th>الأبعاد (م)</th>
             <th>المساحة/الوجه</th>
-            ${data.hidePrices ? '' : '<th>سعر المتر</th><th>إجمالي السعر</th>'}
           </tr>
         </thead>
         <tbody>
@@ -132,17 +131,14 @@ export const generateModernPrintInvoiceHTML = (data: ModernPrintInvoiceData): st
         </tbody>
       </table>
 
-      ${data.hidePrices ? '' : `
       <div class="totals">
         <div class="box">
           <div style="display:flex;justify-content:space-between;font-weight:700;font-size:16px">
-            <div>المجموع الإجمالي:</div>
-            <div style="direction:ltr">${data.totalAmount.toLocaleString('ar-LY')} د.ل</div>
+            <div>إجمالي الأوجه:</div>
+            <div style="direction:ltr">${Number(data.totalAmount || 0).toLocaleString('ar-LY')} وحدة</div>
           </div>
-          <div style="margin-top:8px">المبلغ بالكلمات: ${data.totalAmount ? numberToArabicWords(Number(data.totalAmount)) : ''} ${data.totalAmount ? 'د.ل' : ''}</div>
         </div>
       </div>
-      `}
 
       <div class="notes">${data.notes || ''}</div>
 

--- a/src/components/billing/InvoiceTemplates.tsx
+++ b/src/components/billing/InvoiceTemplates.tsx
@@ -147,6 +147,7 @@ export const generateModernPrintInvoiceHTML = (data: ModernPrintInvoiceData): st
         </tbody>
       </table>
 
+      ${data.hidePrices ? `
       <div class="totals">
         <div class="box">
           <div style="display:flex;justify-content:space-between;font-weight:700;font-size:16px">
@@ -155,6 +156,17 @@ export const generateModernPrintInvoiceHTML = (data: ModernPrintInvoiceData): st
           </div>
         </div>
       </div>
+      ` : `
+      <div class="totals">
+        <div class="box">
+          <div style="display:flex;justify-content:space-between;font-weight:700;font-size:16px">
+            <div>المجموع الإجمالي:</div>
+            <div style="direction:ltr">${data.totalAmount.toLocaleString('ar-LY')} د.ل</div>
+          </div>
+          <div style="margin-top:8px">المبلغ بالكلمات: ${data.totalAmount ? numberToArabicWords(Number(data.totalAmount)) : ''} ${data.totalAmount ? 'د.ل' : ''}</div>
+        </div>
+      </div>
+      `}
 
       <div class="notes">${data.notes || ''}</div>
 
@@ -185,7 +197,7 @@ export const numberToArabicWords = (num: number): string => {
   if (num < 1000) {
     const hundred = Math.floor(num / 100);
     const remainder = num % 100;
-    return ones[hundred] + ' مائة' + (remainder > 0 ? ' ��' + numberToArabicWords(remainder) : '');
+    return ones[hundred] + ' مائة' + (remainder > 0 ? ' و' + numberToArabicWords(remainder) : '');
   }
   if (num < 1000000) {
     const thousand = Math.floor(num / 1000);

--- a/src/components/billing/InvoiceTemplates.tsx
+++ b/src/components/billing/InvoiceTemplates.tsx
@@ -34,7 +34,20 @@ export const generateModernPrintInvoiceHTML = (data: ModernPrintInvoiceData): st
     displayItems.push({ size: '', quantity: '', faces: '', totalFaces: '', width: '', height: '', area: '', pricePerMeter: '', totalPrice: '' } as any);
   }
 
-  const rowsHtml = displayItems.map(item => `
+  const rowsHtml = displayItems.map(item => {
+    if (data.hidePrices) {
+      return `
+      <tr>
+        <td style="padding:8px">${item.size || ''}</td>
+        <td style="padding:8px">${item.quantity ?? ''}</td>
+        <td style="padding:8px">${item.faces ?? ''}</td>
+        <td style="padding:8px">${item.totalFaces ?? ''}</td>
+        <td style="padding:8px">${item.width ?? ''} × ${item.height ?? ''}</td>
+        <td style="padding:8px">${Number(item.area || 0).toFixed(2)} م²</td>
+      </tr>
+    `;
+    }
+    return `
     <tr>
       <td style="padding:8px">${item.size || ''}</td>
       <td style="padding:8px">${item.quantity ?? ''}</td>
@@ -42,8 +55,11 @@ export const generateModernPrintInvoiceHTML = (data: ModernPrintInvoiceData): st
       <td style="padding:8px">${item.totalFaces ?? ''}</td>
       <td style="padding:8px">${item.width ?? ''} × ${item.height ?? ''}</td>
       <td style="padding:8px">${Number(item.area || 0).toFixed(2)} م²</td>
+      <td style="padding:8px">${(Number(item.pricePerMeter || 0)).toLocaleString('ar-LY')}</td>
+      <td style="padding:8px">${(Number(item.totalPrice || 0)).toLocaleString('ar-LY')} د.ل</td>
     </tr>
-  `).join('');
+  `;
+  }).join('');
 
   // Full header + footer to match the dialog preview
   const html = `<!DOCTYPE html>
@@ -110,7 +126,7 @@ export const generateModernPrintInvoiceHTML = (data: ModernPrintInvoiceData): st
 
       <div class="customer-info">
         <div style="display:flex;justify-content:space-between;align-items:center;gap:8px;">
-          <div><strong>العم��ل:</strong> ${data.customerName || ''}</div>
+          <div><strong>العميل:</strong> ${data.customerName || ''}</div>
           <div style="direction:ltr">التاريخ: ${new Date(data.invoiceDate).toLocaleDateString('ar-LY')}</div>
         </div>
       </div>
@@ -169,7 +185,7 @@ export const numberToArabicWords = (num: number): string => {
   if (num < 1000) {
     const hundred = Math.floor(num / 100);
     const remainder = num % 100;
-    return ones[hundred] + ' مائة' + (remainder > 0 ? ' و' + numberToArabicWords(remainder) : '');
+    return ones[hundred] + ' مائة' + (remainder > 0 ? ' ��' + numberToArabicWords(remainder) : '');
   }
   if (num < 1000000) {
     const thousand = Math.floor(num / 1000);

--- a/src/components/billing/InvoiceTemplates.tsx
+++ b/src/components/billing/InvoiceTemplates.tsx
@@ -34,20 +34,7 @@ export const generateModernPrintInvoiceHTML = (data: ModernPrintInvoiceData): st
     displayItems.push({ size: '', quantity: '', faces: '', totalFaces: '', width: '', height: '', area: '', pricePerMeter: '', totalPrice: '' } as any);
   }
 
-  const rowsHtml = displayItems.map(item => {
-    if (data.hidePrices) {
-      return `
-      <tr>
-        <td style="padding:8px">${item.size || ''}</td>
-        <td style="padding:8px">${item.quantity ?? ''}</td>
-        <td style="padding:8px">${item.faces ?? ''}</td>
-        <td style="padding:8px">${item.totalFaces ?? ''}</td>
-        <td style="padding:8px">${item.width ?? ''} × ${item.height ?? ''}</td>
-        <td style="padding:8px">${Number(item.area || 0).toFixed(2)} م²</td>
-      </tr>
-    `;
-    }
-    return `
+  const rowsHtml = displayItems.map(item => `
     <tr>
       <td style="padding:8px">${item.size || ''}</td>
       <td style="padding:8px">${item.quantity ?? ''}</td>
@@ -55,11 +42,8 @@ export const generateModernPrintInvoiceHTML = (data: ModernPrintInvoiceData): st
       <td style="padding:8px">${item.totalFaces ?? ''}</td>
       <td style="padding:8px">${item.width ?? ''} × ${item.height ?? ''}</td>
       <td style="padding:8px">${Number(item.area || 0).toFixed(2)} م²</td>
-      <td style="padding:8px">${(Number(item.pricePerMeter || 0)).toLocaleString('ar-LY')}</td>
-      <td style="padding:8px">${(Number(item.totalPrice || 0)).toLocaleString('ar-LY')} د.ل</td>
     </tr>
-  `;
-  }).join('');
+  `).join('');
 
   // Full header + footer to match the dialog preview
   const html = `<!DOCTYPE html>

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -70,7 +70,7 @@ interface ModernPrintInvoiceDialogProps {
 }
 
 const CURRENCIES = [
-  { code: 'LYD', name: 'دينار ليبي', symbol: 'د.ل', writtenName: 'دينار ��يبي' },
+  { code: 'LYD', name: 'دينار ليبي', symbol: 'د.ل', writtenName: 'دينار ليبي' },
   { code: 'USD', name: 'دولار أمريكي', symbol: '$', writtenName: 'دو��ار أمريكي' },
   { code: 'EUR', name: 'يورو', symbol: '€', writtenName: 'يورو' },
 ];
@@ -404,10 +404,11 @@ export default function ModernPrintInvoiceDialog({
   };
 
   useEffect(() => {
-    if (open && Object.keys(sizeDimensionsMap).length > 0) {
+    // If we're editing an existing saved invoice (initialInvoice), do not override its items
+    if (open && Object.keys(sizeDimensionsMap).length > 0 && !initialInvoice) {
       getBillboardsFromContracts(selectedContracts);
     }
-  }, [selectedContracts, open, contracts, sizeDimensionsMap]);
+  }, [selectedContracts, open, contracts, sizeDimensionsMap, initialInvoice]);
 
   const handleContractToggle = (contractNumber: string) => {
     const isSelected = selectedContracts.includes(contractNumber);
@@ -837,7 +838,7 @@ export default function ModernPrintInvoiceDialog({
               </div>
               
               <div class="footer">
-                شكراً لتعام��كم معنا | Thank you for your business<br>
+                شكراً لتعاملكم معنا | Thank you for your business<br>
                 هذه فاتورة إلكترونية ولا تحتاج إلى ختم أو توقيع
               </div>
             </div>
@@ -1051,7 +1052,7 @@ export default function ModernPrintInvoiceDialog({
               </div>
 
               <div className="text-center mt-4 text-sm text-muted-foreground">
-                المبلغ بالكلم��ت: {formatArabicNumber(total)} {currency.writtenName}
+                المبلغ بالكلمات: {formatArabicNumber(total)} {currency.writtenName}
               </div>
             </div>
           </div>
@@ -1418,7 +1419,7 @@ export default function ModernPrintInvoiceDialog({
               disabled={localPrintItems.length === 0}
             >
               <Printer className="h-4 w-4" />
-              طباعة الفاتور��
+              طباعة الفاتورة
             </Button>
           </div>
         </div>

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -19,6 +19,7 @@ import {
   Save,
   X
 } from 'lucide-react';
+import { generateModernPrintInvoiceHTML } from './InvoiceTemplates';
 
 interface PrintItem {
   size: string;
@@ -126,7 +127,7 @@ export default function ModernPrintInvoiceDialog({
   const [sizeOrderMap, setSizeOrderMap] = useState<{ [key: string]: number }>({});
   const [sizeDimensionsMap, setSizeDimensionsMap] = useState<{ [key: string]: { width: number; height: number } }>({});
 
-  // ✅ جلب بيانات الأحجام من قا��دة البيانات مع الأبعاد
+  // ✅ جلب بيانات الأحجام ��ن قا��دة البيانات مع الأبعاد
   const fetchSizeData = async () => {
     try {
       const { data: sizesData, error } = await supabase
@@ -780,7 +781,7 @@ export default function ModernPrintInvoiceDialog({
                       <tr class="${isEmpty ? 'empty-row' : ''}">
                         <td>${isEmpty ? '' : index + 1}</td>
                         <td style="text-align: right; padding-right: 8px;">
-                          ${isEmpty ? '' : `لوحة إعلا��ية مقاس ${item.size}`}
+                          ${isEmpty ? '' : `لوح�� إعلا��ية مقاس ${item.size}`}
                         </td>
                         <td>${isEmpty ? '' : (typeof item.quantity === 'number' ? formatArabicNumber(item.quantity) : item.quantity)}</td>
                         <td>${isEmpty ? '' : (typeof item.faces === 'number' ? item.faces : item.faces)}</td>
@@ -800,7 +801,7 @@ export default function ModernPrintInvoiceDialog({
                     <span>${formatArabicNumber(subtotal)} وحدة</span>
                   </div>
                   <div class="total-row discount">
-                    <span>خصم (${discountType === 'percentage' ? `${discount}%` : `${formatArabicNumber(discount)} وحدة`}):</span>
+                    <span>خ��م (${discountType === 'percentage' ? `${discount}%` : `${formatArabicNumber(discount)} وحدة`}):</span>
                     <span>- ${formatArabicNumber(discountAmount)} وحدة</span>
                   </div>
                 ` : ''}
@@ -954,7 +955,7 @@ export default function ModernPrintInvoiceDialog({
         <h3 className="expenses-preview-label mb-3 text-lg">بيانات العميل</h3>
         <div className="text-sm space-y-1">
           <div><strong>الاسم:</strong> {customerName}</div>
-          <div><strong>العقود المرتبط��:</strong> {selectedContracts.join(', ')}</div>
+          <div><strong>العقود المرتبط���:</strong> {selectedContracts.join(', ')}</div>
           <div><strong>تاريخ الفاتورة:</strong> {new Date(invoiceDate).toLocaleDateString('ar-LY')}</div>
         </div>
       </div>
@@ -998,7 +999,7 @@ export default function ModernPrintInvoiceDialog({
           <div className="flex justify-end">
             <div className="w-[400px]">
               <div className="flex justify-between py-2 text-sm">
-                <span>إجمالي الأوجه:</span>
+                <span>إجمالي الأو��ه:</span>
                 <span className="expenses-amount-calculated font-bold">{formatArabicNumber(subtotal)} وحدة</span>
               </div>
 

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -76,7 +76,7 @@ const CURRENCIES = [
   { code: 'EUR', name: 'يورو', symbol: '€', writtenName: 'يورو' },
 ];
 
-// ✅ دالة تنسيق الأرقام العربية
+// ✅ دالة تنسيق الأرقام ال��ربية
 const formatArabicNumber = (num: number): string => {
   if (isNaN(num) || num === null || num === undefined) return '0';
   
@@ -380,7 +380,7 @@ export default function ModernPrintInvoiceDialog({
       groupedBillboards[groupKey].totalArea += area;
     });
 
-    // ✅ حساب الأسعار الإج��الية وترتيب النتائج
+    // ✅ حساب الأسعار الإج��الية و��رتيب النتائج
     const result = Object.values(groupedBillboards).map(item => {
       // ✅ الحساب الصحيح: العرض × الارتفاع × عدد الأوجه × سعر المتر
       const calculatedPrice = item.width * item.height * item.totalFaces * item.pricePerMeter;
@@ -808,7 +808,8 @@ export default function ModernPrintInvoiceDialog({
                         <td>${isEmpty ? '' : (typeof item.faces === 'number' ? item.faces : item.faces)}</td>
                         <td>${isEmpty ? '' : (typeof item.totalFaces === 'number' ? formatArabicNumber(item.totalFaces) : item.totalFaces)}</td>
                         <td>${isEmpty ? '' : (typeof item.width === 'number' && typeof item.height === 'number' ? `${item.width} × ${item.height}` : '')}</td>
-                        <td>${isEmpty ? '' : (typeof item.area === 'number' && typeof item.totalFaces === 'number' ? `${(item.area * item.totalFaces).toFixed(2)} م²` : item.area)}</td>
+                        <td>${isEmpty ? '' : `${totalAreaForFaces.toFixed(2)} م²`}</td>
+                        ${!isPrinterCopy ? `<td>${isEmpty ? '' : formatArabicNumber(pricePerMeterVal)} ${currency.symbol}</td><td>${isEmpty ? '' : formatArabicNumber(itemTotalPriceVal)} ${currency.symbol}</td>` : ''}
                       </tr>
                     `;
                   }).join('')}
@@ -946,7 +947,7 @@ export default function ModernPrintInvoiceDialog({
       if (error) {
         console.error('Failed to save printed invoice:', error);
         const errMsg = (error && (error.message || error.code)) ? `${error.message || error.code}` : JSON.stringify(error);
-        toast.error(`فشل حفظ الفاتورة: ${errMsg}`);
+        toast.error(`فشل حفظ ال��اتورة: ${errMsg}`);
         return;
       }
 
@@ -1037,7 +1038,7 @@ export default function ModernPrintInvoiceDialog({
           <div className="flex justify-end">
             <div className="w-[400px]">
               <div className="flex justify-between py-2 text-sm">
-                <span>المجموع الفرعي:</span>
+                <span>المجموع ا��فرعي:</span>
                 <span className="expenses-amount-calculated font-bold">{formatArabicNumber(moneySubtotal)} {currency.symbol}</span>
               </div>
 
@@ -1302,7 +1303,7 @@ export default function ModernPrintInvoiceDialog({
                       <div className="expenses-empty-state py-12">
                         <Calculator className="h-16 w-16 mx-auto mb-4 opacity-50" />
                         <p className="text-lg">لا توجد عناصر للطباعة</p>
-                        <p className="text-sm">لم يتم العثور على لوحات مرتبطة بالعقود المحددة</p>
+                        <p className="text-sm">لم يتم العثور على لوحات مرتبطة ��العقود المحددة</p>
                       </div>
                     ) : (
                       <div className="space-y-4">

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -126,7 +126,7 @@ export default function ModernPrintInvoiceDialog({
   const [sizeOrderMap, setSizeOrderMap] = useState<{ [key: string]: number }>({});
   const [sizeDimensionsMap, setSizeDimensionsMap] = useState<{ [key: string]: { width: number; height: number } }>({});
 
-  // ✅ جلب بيانات الأحجام من قاعدة البيانات مع الأبعاد
+  // ✅ جلب بيانات الأحجام من قا��دة البيانات مع الأبعاد
   const fetchSizeData = async () => {
     try {
       const { data: sizesData, error } = await supabase
@@ -430,7 +430,7 @@ export default function ModernPrintInvoiceDialog({
       item.totalArea = item.area * item.totalFaces;
     }
     
-    // ✅ الحساب الصحيح: العرض × الارتفاع × عدد الأوج�� × سعر المتر
+    // ✅ الحساب الصحيح: العرض × الارتفاع × ��دد الأوج�� × سعر المتر
     item.totalPrice = item.width * item.height * item.totalFaces * item.pricePerMeter;
     
     updatedItems[index] = item;
@@ -780,7 +780,7 @@ export default function ModernPrintInvoiceDialog({
                       <tr class="${isEmpty ? 'empty-row' : ''}">
                         <td>${isEmpty ? '' : index + 1}</td>
                         <td style="text-align: right; padding-right: 8px;">
-                          ${isEmpty ? '' : `لوحة إعلانية مقاس ${item.size}`}
+                          ${isEmpty ? '' : `لوحة إعلا��ية مقاس ${item.size}`}
                         </td>
                         <td>${isEmpty ? '' : (typeof item.quantity === 'number' ? formatArabicNumber(item.quantity) : item.quantity)}</td>
                         <td>${isEmpty ? '' : (typeof item.faces === 'number' ? item.faces : item.faces)}</td>
@@ -973,8 +973,6 @@ export default function ModernPrintInvoiceDialog({
                   <th className="border border-border p-3 text-center font-bold">إجمالي الأوجه</th>
                   <th className="border border-border p-3 text-center font-bold">الأبعاد (م)</th>
                   <th className="border border-border p-3 text-center font-bold">المساحة/الوجه</th>
-                  <th className="border border-border p-3 text-center font-bold">سعر المتر</th>
-                  <th className="border border-border p-3 text-center font-bold">إجمالي السعر</th>
                 </tr>
               </thead>
               <tbody>
@@ -986,8 +984,6 @@ export default function ModernPrintInvoiceDialog({
                     <td className="border border-border p-3 text-center font-medium">{formatArabicNumber(item.totalFaces)}</td>
                     <td className="border border-border p-3 text-center">{item.width} × {item.height}</td>
                     <td className="border border-border p-3 text-center">{item.area.toFixed(2)} م²</td>
-                    <td className="border border-border p-3 text-center">{formatArabicNumber(item.pricePerMeter)} {currency.symbol}</td>
-                    <td className="border border-border p-3 text-center expenses-amount-calculated font-bold">{formatArabicNumber(item.totalPrice)} {currency.symbol}</td>
                   </tr>
                 ))}
               </tbody>
@@ -1002,32 +998,22 @@ export default function ModernPrintInvoiceDialog({
           <div className="flex justify-end">
             <div className="w-[400px]">
               <div className="flex justify-between py-2 text-sm">
-                <span>المجموع الفرعي:</span>
-                <span className="expenses-amount-calculated font-bold">{formatArabicNumber(subtotal)} {currency.symbol}</span>
+                <span>إجمالي الأوجه:</span>
+                <span className="expenses-amount-calculated font-bold">{formatArabicNumber(subtotal)} وحدة</span>
               </div>
-              
+
               {discount > 0 && (
                 <div className="flex justify-between py-2 text-sm text-green-400">
-                  <span>خصم ({discountType === 'percentage' ? `${discount}%` : `${formatArabicNumber(discount)} ${currency.symbol}`}):</span>
-                  <span className="font-bold">- {formatArabicNumber(discountAmount)} {currency.symbol}</span>
-                </div>
-              )}
-
-              {includeAccountBalance && accountPayments > 0 && (
-                <div className="flex justify-between py-2 text-sm stat-blue">
-                  <span>رصيد الحساب:</span>
-                  <span className="font-bold">- {formatArabicNumber(accountPayments)} {currency.symbol}</span>
+                  <span>خصم ({discountType === 'percentage' ? `${discount}%` : `${formatArabicNumber(discount)} وحدة`}):</span>
+                  <span className="font-bold">- {formatArabicNumber(discountAmount)} وحدة</span>
                 </div>
               )}
 
               <div className="flex justify-between py-4 text-xl font-bold bg-primary text-primary-foreground px-6 rounded-lg mt-4">
-                <span>المجموع الإجمالي:</span>
-                <span className="text-primary-glow">{formatArabicNumber(total)} {currency.symbol}</span>
+                <span>العدد النهائي للأوجه:</span>
+                <span className="text-primary-glow">{formatArabicNumber(total)} وحدة</span>
               </div>
 
-              <div className="text-center mt-4 text-sm text-muted-foreground">
-                المبلغ بالكلمات: {formatArabicNumber(total)} {currency.writtenName}
-              </div>
             </div>
           </div>
         </div>

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -127,7 +127,7 @@ export default function ModernPrintInvoiceDialog({
   const [sizeOrderMap, setSizeOrderMap] = useState<{ [key: string]: number }>({});
   const [sizeDimensionsMap, setSizeDimensionsMap] = useState<{ [key: string]: { width: number; height: number } }>({});
 
-  // ✅ جلب بيانات الأحجام ��ن قا��دة البيانات مع الأبعاد
+  // ✅ جلب بيانات الأحجام من قا��دة البيانات مع الأبعاد
   const fetchSizeData = async () => {
     try {
       const { data: sizesData, error } = await supabase
@@ -498,6 +498,41 @@ export default function ModernPrintInvoiceDialog({
           } as any);
         }
 
+        // If this is a customer copy (not a printer copy), use the centralized HTML generator with prices
+        const isPrinterCopy = !!autoPrintForPrinter || !!printForPrinter;
+        const moneySubtotal = localPrintItems.reduce((s, it) => s + ((Number(it.width)||0) * (Number(it.height)||0) * (Number(it.totalFaces)||0) * (Number(it.pricePerMeter)||0)), 0);
+        if (!isPrinterCopy) {
+          const itemsForGenerator = displayItems.map(it => ({
+            size: it.size || '',
+            quantity: it.quantity || 0,
+            faces: it.faces || 0,
+            totalFaces: it.totalFaces || 0,
+            width: it.width || 0,
+            height: it.height || 0,
+            area: it.area || 0,
+            pricePerMeter: it.pricePerMeter || 0,
+            totalPrice: it.totalPrice || 0,
+          }));
+
+          const html = generateModernPrintInvoiceHTML({
+            invoiceNumber,
+            invoiceType: 'فاتورة طباعة',
+            invoiceDate,
+            customerName,
+            items: itemsForGenerator,
+            totalAmount: moneySubtotal,
+            notes,
+            printerName: 'web',
+            hidePrices: false,
+          });
+
+          printWindow.document.open();
+          printWindow.document.write(html);
+          printWindow.document.close();
+          toast.success(`تم فتح الفاتورة للطباعة بنجاح بعملة ${currency.name}!`);
+          return;
+        }
+
         const htmlContent = `
           <!DOCTYPE html>
           <html dir="rtl" lang="ar">
@@ -781,7 +816,7 @@ export default function ModernPrintInvoiceDialog({
                       <tr class="${isEmpty ? 'empty-row' : ''}">
                         <td>${isEmpty ? '' : index + 1}</td>
                         <td style="text-align: right; padding-right: 8px;">
-                          ${isEmpty ? '' : `لوح�� إعلا��ية مقاس ${item.size}`}
+                          ${isEmpty ? '' : `لوحة إعلا��ية مقاس ${item.size}`}
                         </td>
                         <td>${isEmpty ? '' : (typeof item.quantity === 'number' ? formatArabicNumber(item.quantity) : item.quantity)}</td>
                         <td>${isEmpty ? '' : (typeof item.faces === 'number' ? item.faces : item.faces)}</td>
@@ -801,7 +836,7 @@ export default function ModernPrintInvoiceDialog({
                     <span>${formatArabicNumber(subtotal)} وحدة</span>
                   </div>
                   <div class="total-row discount">
-                    <span>خ��م (${discountType === 'percentage' ? `${discount}%` : `${formatArabicNumber(discount)} وحدة`}):</span>
+                    <span>خصم (${discountType === 'percentage' ? `${discount}%` : `${formatArabicNumber(discount)} وحدة`}):</span>
                     <span>- ${formatArabicNumber(discountAmount)} وحدة</span>
                   </div>
                 ` : ''}
@@ -955,7 +990,7 @@ export default function ModernPrintInvoiceDialog({
         <h3 className="expenses-preview-label mb-3 text-lg">بيانات العميل</h3>
         <div className="text-sm space-y-1">
           <div><strong>الاسم:</strong> {customerName}</div>
-          <div><strong>العقود المرتبط���:</strong> {selectedContracts.join(', ')}</div>
+          <div><strong>العقود المرتبط��:</strong> {selectedContracts.join(', ')}</div>
           <div><strong>تاريخ الفاتورة:</strong> {new Date(invoiceDate).toLocaleDateString('ar-LY')}</div>
         </div>
       </div>
@@ -999,7 +1034,7 @@ export default function ModernPrintInvoiceDialog({
           <div className="flex justify-end">
             <div className="w-[400px]">
               <div className="flex justify-between py-2 text-sm">
-                <span>إجمالي الأو��ه:</span>
+                <span>إجمالي الأوجه:</span>
                 <span className="expenses-amount-calculated font-bold">{formatArabicNumber(subtotal)} وحدة</span>
               </div>
 

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -70,7 +70,7 @@ interface ModernPrintInvoiceDialogProps {
 }
 
 const CURRENCIES = [
-  { code: 'LYD', name: 'دينار ليبي', symbol: 'د.ل', writtenName: 'دينار ليبي' },
+  { code: 'LYD', name: 'دينار ليبي', symbol: 'د.ل', writtenName: 'دينار ��يبي' },
   { code: 'USD', name: 'دولار أمريكي', symbol: '$', writtenName: 'دو��ار أمريكي' },
   { code: 'EUR', name: 'يورو', symbol: '€', writtenName: 'يورو' },
 ];
@@ -202,9 +202,12 @@ export default function ModernPrintInvoiceDialog({
       if (initialInvoice) {
         try {
           const inv = initialInvoice as any;
+          console.log('ModernPrintInvoiceDialog: initialInvoice received:', inv);
           // parse print items from multiple possible fields (print_items, print_items_json, items, items_json)
           let items: any[] = [];
           const possible = inv.print_items ?? inv.print_items_json ?? inv.items ?? inv.items_json ?? null;
+
+          console.log('ModernPrintInvoiceDialog: possible items field:', possible ? typeof possible : 'none');
 
           if (possible) {
             try {
@@ -222,7 +225,7 @@ export default function ModernPrintInvoiceDialog({
             }
           }
 
-          setLocalPrintItems((items || []).map((it:any) => ({
+          const mapped = (items || []).map((it:any) => ({
             size: it.size || it.name || '',
             quantity: Number(it.quantity ?? it.qty ?? 0) || 0,
             faces: Number(it.faces ?? it.face_count ?? it.Number_of_Faces ?? 0) || 0,
@@ -234,7 +237,11 @@ export default function ModernPrintInvoiceDialog({
             sortOrder: Number(it.sortOrder ?? it.sort_order ?? 0) || 0,
             width: Number(it.width || it.w || 0) || 0,
             height: Number(it.height || it.h || 0) || 0,
-          })));
+          }));
+
+          console.log('ModernPrintInvoiceDialog: parsed items count:', mapped.length, mapped);
+
+          setLocalPrintItems(mapped);
 
           if (inv.invoice_number) setInvoiceNumber(inv.invoice_number);
           if (inv.invoice_date) setInvoiceDate(typeof inv.invoice_date === 'string' ? inv.invoice_date.slice(0,10) : new Date(inv.invoice_date).toISOString().slice(0,10));
@@ -830,7 +837,7 @@ export default function ModernPrintInvoiceDialog({
               </div>
               
               <div class="footer">
-                شكراً لتعاملكم معنا | Thank you for your business<br>
+                شكراً لتعام��كم معنا | Thank you for your business<br>
                 هذه فاتورة إلكترونية ولا تحتاج إلى ختم أو توقيع
               </div>
             </div>
@@ -1044,7 +1051,7 @@ export default function ModernPrintInvoiceDialog({
               </div>
 
               <div className="text-center mt-4 text-sm text-muted-foreground">
-                المبلغ بالكلمات: {formatArabicNumber(total)} {currency.writtenName}
+                المبلغ بالكلم��ت: {formatArabicNumber(total)} {currency.writtenName}
               </div>
             </div>
           </div>
@@ -1411,7 +1418,7 @@ export default function ModernPrintInvoiceDialog({
               disabled={localPrintItems.length === 0}
             >
               <Printer className="h-4 w-4" />
-              طباعة الفاتورة
+              طباعة الفاتور��
             </Button>
           </div>
         </div>

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -159,7 +159,7 @@ export default function ModernPrintInvoiceDialog({
     }
   };
 
-  // ✅ المجموعات: المجموع النقدي وإجمالي الأوجه
+  // ✅ المجموعات: المجموع النقدي وإج��الي الأوجه
   const moneySubtotal = useMemo(() => {
     let sum = 0;
     localPrintItems.forEach((item, index) => {
@@ -547,7 +547,7 @@ export default function ModernPrintInvoiceDialog({
           printWindow.document.open();
           printWindow.document.write(html);
           printWindow.document.close();
-          toast.success(`تم فتح الفاتورة للطباعة بنجاح بعملة ${currency.name}!`);
+          toast.success(`تم فتح الفاتورة للطباعة بنجاح بعم��ة ${currency.name}!`);
           return;
         }
 
@@ -823,7 +823,7 @@ export default function ModernPrintInvoiceDialog({
                     <th style="width: 12%">أوجه/لوحة</th>
                     <th style="width: 12%">إجمالي الأوجه</th>
                     <th style="width: 18%">الأبعاد (م)</th>
-                    <th style="width: 10%">مساحة الأوجه (م²)</th>
+                    <th style="width: 10%">مساحة الأوجه (م��)</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -850,7 +850,7 @@ export default function ModernPrintInvoiceDialog({
               <div class="total-section">
                 ${facesTotal > 0 ? `
                   <div class="total-row subtotal">
-                    <span>إجمالي الأوجه:</span>
+                    <span>��جمالي الأوجه:</span>
                     <span>${formatArabicNumber(facesTotal)} وحدة</span>
                   </div>
                 ` : ''}
@@ -910,7 +910,7 @@ export default function ModernPrintInvoiceDialog({
 
       } catch (error) {
         console.error('Error in print invoice:', error);
-        const errorMessage = error instanceof Error ? error.message : 'خطأ غير معروف';
+        const errorMessage = error instanceof Error ? error.message : 'خطأ غير م��روف';
         toast.error(`حدث خطأ أثناء تحضير الفاتورة للطباعة: ${errorMessage}`);
       }
     };
@@ -932,7 +932,7 @@ export default function ModernPrintInvoiceDialog({
 
     try {
       // Use computed subtotal/discount/total from component state
-      const subtotalValue = Number(subtotal) || 0;
+      const subtotalValue = Number(moneySubtotal) || 0;
       const discountAmountValue = Number(discountAmount) || 0;
       const totalValue = Number(total) || 0;
 

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -344,7 +344,7 @@ export default function ModernPrintInvoiceDialog({
       const size = String(billboard.Size ?? billboard.size ?? 'غير محدد');
       const faces = Number(billboard.Faces ?? billboard.faces ?? billboard.Number_of_Faces ?? billboard.Faces_Count ?? billboard.faces_count ?? 1);
       
-      // ✅ جلب الأبعاد من قاعدة البيانات
+      // ✅ جلب الأبعاد م�� قاعدة البيانات
       const dimensions = sizeDimensionsMap[size];
       const width = dimensions?.width || 0;
       const height = dimensions?.height || 0;
@@ -499,7 +499,7 @@ export default function ModernPrintInvoiceDialog({
         }
 
         // If this is a customer copy (not a printer copy), use the centralized HTML generator with prices
-        const isPrinterCopy = !!autoPrintForPrinter || !!printForPrinter;
+        const isPrinterCopy = Boolean(autoPrintForPrinter);
         const moneySubtotal = localPrintItems.reduce((s, it) => s + ((Number(it.width)||0) * (Number(it.height)||0) * (Number(it.totalFaces)||0) * (Number(it.pricePerMeter)||0)), 0);
         if (!isPrinterCopy) {
           const itemsForGenerator = displayItems.map(it => ({
@@ -980,7 +980,7 @@ export default function ModernPrintInvoiceDialog({
           <div className="text-sm text-muted-foreground">
             رقم الفاتورة: {invoiceNumber}<br />
             التاريخ: {new Date(invoiceDate).toLocaleDateString('ar-LY')}<br />
-            العملة: {currency.name}
+            العمل��: {currency.name}
           </div>
         </div>
       </div>

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -76,7 +76,7 @@ const CURRENCIES = [
   { code: 'EUR', name: 'يورو', symbol: '€', writtenName: 'يورو' },
 ];
 
-// ✅ دالة تنسيق الأرقام ال��ربية
+// ✅ دالة تنسيق الأرقام العربية
 const formatArabicNumber = (num: number): string => {
   if (isNaN(num) || num === null || num === undefined) return '0';
   
@@ -380,7 +380,7 @@ export default function ModernPrintInvoiceDialog({
       groupedBillboards[groupKey].totalArea += area;
     });
 
-    // ✅ حساب الأسعار الإج��الية و��رتيب النتائج
+    // ✅ حساب الأسعار الإج��الية وترتيب النتائج
     const result = Object.values(groupedBillboards).map(item => {
       // ✅ الحساب الصحيح: العرض × الارتفاع × عدد الأوجه × سعر المتر
       const calculatedPrice = item.width * item.height * item.totalFaces * item.pricePerMeter;
@@ -824,24 +824,31 @@ export default function ModernPrintInvoiceDialog({
                   </div>
                 ` : ''}
 
-                ${moneySubtotal > 0 ? `
+                ${!isPrinterCopy && moneySubtotal > 0 ? `
                   <div class="total-row subtotal">
                     <span>المجموع الفرعي:</span>
                     <span>${formatArabicNumber(moneySubtotal)} ${currency.symbol}</span>
                   </div>
                 ` : ''}
 
-                ${discount > 0 ? `
+                ${!isPrinterCopy && discount > 0 ? `
                   <div class="total-row discount">
                     <span>خصم (${discountType === 'percentage' ? `${discount}%` : `${formatArabicNumber(discount)} ${currency.symbol}`}):</span>
                     <span>- ${formatArabicNumber(discountAmount)} ${currency.symbol}</span>
                   </div>
                 ` : ''}
 
-                <div class="total-row grand-total">
-                  <span>الإجمالي النهائي:</span>
-                  <span class="currency">${formatArabicNumber(total)} ${currency.symbol}</span>
-                </div>
+                ${isPrinterCopy ? `
+                  <div class="total-row grand-total">
+                    <span>العدد النهائي للأوجه:</span>
+                    <span class="currency">${formatArabicNumber(facesTotal)} وحدة</span>
+                  </div>
+                ` : `
+                  <div class="total-row grand-total">
+                    <span>الإجمالي النهائي:</span>
+                    <span class="currency">${formatArabicNumber(total)} ${currency.symbol}</span>
+                  </div>
+                `}
               </div>
               
               <div class="footer">
@@ -947,7 +954,7 @@ export default function ModernPrintInvoiceDialog({
       if (error) {
         console.error('Failed to save printed invoice:', error);
         const errMsg = (error && (error.message || error.code)) ? `${error.message || error.code}` : JSON.stringify(error);
-        toast.error(`فشل حفظ ال��اتورة: ${errMsg}`);
+        toast.error(`فشل حفظ الفاتورة: ${errMsg}`);
         return;
       }
 
@@ -1005,7 +1012,7 @@ export default function ModernPrintInvoiceDialog({
                   <th className="border border-border p-3 text-center font-bold">إجمالي الأوجه</th>
                   <th className="border border-border p-3 text-center font-bold">الأبعاد (م)</th>
                   <th className="border border-border p-3 text-center font-bold">المساحة/الوجه</th>
-                  <th className="border border-border p-3 text-center font-bold">سعر المتر ({currency.symbol})</th>
+                  <th className="border border-border p-3 text-center font-bold">س��ر المتر ({currency.symbol})</th>
                   <th className="border border-border p-3 text-center font-bold">الإجمالي ({currency.symbol})</th>
                 </tr>
               </thead>
@@ -1038,7 +1045,7 @@ export default function ModernPrintInvoiceDialog({
           <div className="flex justify-end">
             <div className="w-[400px]">
               <div className="flex justify-between py-2 text-sm">
-                <span>المجموع ا��فرعي:</span>
+                <span>المجموع الفرعي:</span>
                 <span className="expenses-amount-calculated font-bold">{formatArabicNumber(moneySubtotal)} {currency.symbol}</span>
               </div>
 
@@ -1218,7 +1225,7 @@ export default function ModernPrintInvoiceDialog({
                             onClick={(e) => e.stopPropagation()}
                           />
                           <div className="flex-1">
-                            <div className="expenses-contract-number text-sm">عقد رقم {contract.Contract_Number}</div>
+                            <div className="expenses-contract-number text-sm">ع��د رقم {contract.Contract_Number}</div>
                             <div className="expenses-preview-text text-xs">{contract['Ad Type']}</div>
                           </div>
                           <Badge variant="outline" className="border-primary text-primary text-xs px-2 py-1">
@@ -1303,7 +1310,7 @@ export default function ModernPrintInvoiceDialog({
                       <div className="expenses-empty-state py-12">
                         <Calculator className="h-16 w-16 mx-auto mb-4 opacity-50" />
                         <p className="text-lg">لا توجد عناصر للطباعة</p>
-                        <p className="text-sm">لم يتم العثور على لوحات مرتبطة ��العقود المحددة</p>
+                        <p className="text-sm">لم يتم العثور على لوحات مرتبطة بالعقود المحددة</p>
                       </div>
                     ) : (
                       <div className="space-y-4">

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -162,7 +162,7 @@ export default function ModernPrintInvoiceDialog({
     let calculatedTotal = 0;
     
     localPrintItems.forEach((item, index) => {
-      // ✅ الحساب الصحيح: العرض × الارتفاع × عدد الأوجه × سعر المتر
+      // ✅ الحساب الصحيح: العرض × الارتفاع × عدد الأوجه × سعر ا��متر
       const width = Number(item.width) || 0;
       const height = Number(item.height) || 0;
       const totalFaces = Number(item.totalFaces) || 0;
@@ -227,10 +227,10 @@ export default function ModernPrintInvoiceDialog({
             quantity: Number(it.quantity ?? it.qty ?? 0) || 0,
             faces: Number(it.faces ?? it.face_count ?? it.Number_of_Faces ?? 0) || 0,
             totalFaces: Number(it.totalFaces ?? it.total_faces ?? 0) || 0,
-            area: Number(it.area ?? it.area_m2 ?? (Number(it.width || 0) * Number(it.height || 0)) || 0) || 0,
-            pricePerMeter: Number(it.pricePerMeter ?? it.print_price ?? it.price || 0) || 0,
-            totalArea: Number(it.totalArea ?? it.total_area ?? 0) || 0,
-            totalPrice: Number(it.totalPrice ?? it.total_price ?? it.price_total ?? 0) || 0,
+            area: Number((it.area ?? it.area_m2 ?? (Number(it.width || 0) * Number(it.height || 0))) || 0) || 0,
+            pricePerMeter: Number((it.pricePerMeter ?? it.print_price ?? it.price) || 0) || 0,
+            totalArea: Number((it.totalArea ?? it.total_area ?? 0) || 0) || 0,
+            totalPrice: Number((it.totalPrice ?? it.total_price ?? it.price_total) || 0) || 0,
             sortOrder: Number(it.sortOrder ?? it.sort_order ?? 0) || 0,
             width: Number(it.width || it.w || 0) || 0,
             height: Number(it.height || it.h || 0) || 0,
@@ -433,7 +433,7 @@ export default function ModernPrintInvoiceDialog({
       item.totalArea = item.area * item.totalFaces;
     }
     
-    // ✅ الحساب الصحيح: العرض × الارتفاع × عدد الأوجه × سعر المتر
+    // ✅ الحساب الصحيح: العرض × الارتفاع × عدد الأوج�� × سعر المتر
     item.totalPrice = item.width * item.height * item.totalFaces * item.pricePerMeter;
     
     updatedItems[index] = item;
@@ -854,7 +854,7 @@ export default function ModernPrintInvoiceDialog({
           throw new Error('فشل في فتح نافذة الطباعة. يرجى التحقق من إعدادات المتصفح والسماح بالنوافذ المنبثقة.');
         }
 
-        // ✅ تعيين عنوان النافذة مع معلومات العميل والعقود والتاريخ
+        // ✅ تعي��ن عنوان النافذة مع معلومات العميل والعقود والتاريخ
         printWindow.document.title = fileName;
 
         printWindow.document.open();
@@ -1044,7 +1044,7 @@ export default function ModernPrintInvoiceDialog({
               </div>
 
               <div className="text-center mt-4 text-sm text-muted-foreground">
-                المبلغ ب��لكلمات: {formatArabicNumber(total)} {currency.writtenName}
+                المبلغ بالكلمات: {formatArabicNumber(total)} {currency.writtenName}
               </div>
             </div>
           </div>
@@ -1208,7 +1208,7 @@ export default function ModernPrintInvoiceDialog({
                     </div>
                     <div className="mt-4 p-3 bg-muted/50 rounded-lg">
                       <p className="text-xs text-muted-foreground">
-                        💡 انقر على أي صف لاختيار العقد، أو انقر على المربع للتحديد المباشر
+                        💡 انقر على أي صف لاختيار العقد، أو ان��ر على المربع للتحديد المباشر
                       </p>
                     </div>
                   </CardContent>
@@ -1411,7 +1411,7 @@ export default function ModernPrintInvoiceDialog({
               disabled={localPrintItems.length === 0}
             >
               <Printer className="h-4 w-4" />
-              طباعة الفا��ورة
+              طباعة الفاتورة
             </Button>
           </div>
         </div>

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -159,42 +159,31 @@ export default function ModernPrintInvoiceDialog({
 
   // ✅ حساب الإجماليات الصحيح
   const subtotal = useMemo(() => {
-    let calculatedTotal = 0;
-    
+    let facesTotal = 0;
+
     localPrintItems.forEach((item, index) => {
-      // ✅ الحساب الصحيح: العرض × الارتفاع × عدد الأوجه × سعر ا��متر
-      const width = Number(item.width) || 0;
-      const height = Number(item.height) || 0;
       const totalFaces = Number(item.totalFaces) || 0;
-      const pricePerMeter = Number(item.pricePerMeter) || 0;
-      
-      const itemTotal = width * height * totalFaces * pricePerMeter;
-      
-      console.log(`Item ${index} (${item.size}): ${width} × ${height} × ${totalFaces} × ${pricePerMeter} = ${itemTotal}`);
-      
-      if (!isNaN(itemTotal) && itemTotal > 0) {
-        calculatedTotal += itemTotal;
-      }
+      facesTotal += totalFaces;
+      console.log(`Item ${index} (${item.size}): totalFaces = ${totalFaces}`);
     });
-    
-    console.log('Final subtotal calculated:', calculatedTotal);
-    return calculatedTotal;
+
+    console.log('Final subtotal (faces) calculated:', facesTotal);
+    return facesTotal;
   }, [localPrintItems]);
 
+  // Discount interpreted as percentage or fixed count of faces
   const discountAmount = useMemo(() => {
     if (discountType === 'percentage') {
-      return (subtotal * discount) / 100;
+      return Math.round((subtotal * discount) / 100);
     }
-    return discount;
+    return Number(discount) || 0;
   }, [subtotal, discount, discountType]);
 
   const total = useMemo(() => {
     let finalTotal = subtotal - discountAmount;
-    if (includeAccountBalance && accountPayments > 0) {
-      finalTotal -= accountPayments;
-    }
+    // includeAccountBalance and accountPayments are monetary; ignore when counting faces
     return Math.max(0, finalTotal);
-  }, [subtotal, discountAmount, includeAccountBalance, accountPayments]);
+  }, [subtotal, discountAmount]);
 
   useEffect(() => {
     if (open) {
@@ -341,7 +330,7 @@ export default function ModernPrintInvoiceDialog({
 
     } catch (error) {
       console.error('Error fetching billboards from contracts:', error);
-      toast.error('حدث خطأ في جلب بيانات اللوحات');
+      toast.error('حدث خطأ في جلب بي��نات اللوحات');
       setLocalPrintItems([]);
     }
   };
@@ -384,7 +373,7 @@ export default function ModernPrintInvoiceDialog({
       groupedBillboards[groupKey].totalArea += area;
     });
 
-    // ✅ حساب الأسعار الإجمالية وترتيب النتائج
+    // ✅ حساب الأسعار الإج��الية وترتيب النتائج
     const result = Object.values(groupedBillboards).map(item => {
       // ✅ الحساب الصحيح: العرض × الارتفاع × عدد الأوجه × سعر المتر
       const calculatedPrice = item.width * item.height * item.totalFaces * item.pricePerMeter;
@@ -869,7 +858,7 @@ export default function ModernPrintInvoiceDialog({
         printWindow.document.write(htmlContent);
         printWindow.document.close();
 
-        toast.success(`تم فتح الفاتورة للطباعة بنجاح بعملة ${currency.name}!`);
+        toast.success(`تم فتح الفاتورة للطباعة بنجاح بع��لة ${currency.name}!`);
 
       } catch (error) {
         console.error('Error in print invoice:', error);

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -380,9 +380,9 @@ export default function ModernPrintInvoiceDialog({
       groupedBillboards[groupKey].totalArea += area;
     });
 
-    // ✅ حساب الأسع��ر الإج��الية وترتيب النتائج
+    // ✅ حساب الأسعار الإج��الية وترتيب النتائج
     const result = Object.values(groupedBillboards).map(item => {
-      // ✅ الحساب الصحيح: العرض × الارتفاع × عدد ال��وجه × سعر المتر
+      // ✅ الحساب الصحيح: العرض × الارتفاع × عدد الأوجه × سعر المتر
       const calculatedPrice = item.width * item.height * item.totalFaces * item.pricePerMeter;
       
       console.log(`Processing item ${item.size}: ${item.width} × ${item.height} × ${item.totalFaces} × ${item.pricePerMeter} = ${calculatedPrice}`);
@@ -506,8 +506,8 @@ export default function ModernPrintInvoiceDialog({
           } as any);
         }
 
-        // If this is a customer copy (not a printer copy), use the centralized HTML generator with prices
-        const isPrinterCopy = Boolean(autoPrintForPrinter);
+        // Determine whether this print should be printer-only (faces) or customer (with prices)
+        const isPrinterCopy = Boolean(isPrinterCopyParam);
         const moneySubtotal = localPrintItems.reduce((s, it) => s + ((Number(it.width)||0) * (Number(it.height)||0) * (Number(it.totalFaces)||0) * (Number(it.pricePerMeter)||0)), 0);
 
         const windowFeatures = 'width=1200,height=800,scrollbars=yes,resizable=yes,toolbar=no,menubar=no,location=no,status=no';
@@ -876,7 +876,7 @@ export default function ModernPrintInvoiceDialog({
               </div>
               
               <div class="footer">
-                شكراً لتعاملكم معنا | Thank you for your business<br>
+                شكراً لتعاملكم م��نا | Thank you for your business<br>
                 هذه فاتورة إلكترونية ولا تحتاج إلى ختم أو توقيع
               </div>
             </div>
@@ -1168,7 +1168,7 @@ export default function ModernPrintInvoiceDialog({
                           className="text-right text-sm p-3 h-10 bg-muted cursor-not-allowed"
                           title="رقم الفاتورة يتم توليده تلقائياً"
                         />
-                        <p className="text-xs text-muted-foreground mt-1">يتم توليد ��قم الفاتورة تلقائياً</p>
+                        <p className="text-xs text-muted-foreground mt-1">يتم توليد رقم الفاتورة تلقائياً</p>
                       </div>
                       <div>
                         <label className="expenses-form-label mb-2 block text-sm">التاريخ</label>

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -876,7 +876,7 @@ export default function ModernPrintInvoiceDialog({
               </div>
               
               <div class="footer">
-                شكراً لتعاملكم م��نا | Thank you for your business<br>
+                شكراً لتعاملكم معنا | Thank you for your business<br>
                 هذه فاتورة إلكترونية ولا تحتاج إلى ختم أو توقيع
               </div>
             </div>
@@ -1450,12 +1450,22 @@ export default function ModernPrintInvoiceDialog({
               حفظ في الحساب
             </Button>
             <Button
-              onClick={handlePrint}
+              onClick={() => handlePrint(false)}
               className="expenses-action-btn bg-gradient-to-r from-primary to-primary-glow text-sm px-6 py-2"
               disabled={localPrintItems.length === 0}
             >
               <Printer className="h-4 w-4" />
-              طباعة الفاتورة
+              طباعة (مع الأسعار)
+            </Button>
+
+            <Button
+              onClick={() => handlePrint(true)}
+              variant="outline"
+              className="expenses-action-btn text-sm px-6 py-2"
+              disabled={localPrintItems.length === 0}
+            >
+              <Printer className="h-4 w-4" />
+              للطابعة (أوجه فقط)
             </Button>
           </div>
         </div>

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -122,7 +122,8 @@ export default function ModernPrintInvoiceDialog({
   const [notes, setNotes] = useState('');
   const [discount, setDiscount] = useState(0);
   const [discountType, setDiscountType] = useState<'percentage' | 'fixed'>('percentage');
-  
+  const [invoiceType, setInvoiceType] = useState<'print_only' | 'print_install' | 'install_only'>('print_only');
+
   const [localPrintItems, setLocalPrintItems] = useState<PrintItem[]>([]);
   const [sizeOrderMap, setSizeOrderMap] = useState<{ [key: string]: number }>({});
   const [sizeDimensionsMap, setSizeDimensionsMap] = useState<{ [key: string]: { width: number; height: number } }>({});
@@ -473,12 +474,14 @@ export default function ModernPrintInvoiceDialog({
         const currentDate = new Date(invoiceDate);
         const formattedDate = currentDate.toLocaleDateString('ar-LY');
         
-        // ✅ إنشاء اسم الملف مع معلومات العميل و��لعقود والتاريخ
+        // ✅ إنشاء اسم الملف مع معلومات العميل و العقود والتاريخ
         const contractsList = selectedContracts.join('-');
         const dateFormatted = currentDate.toISOString().slice(0, 10).replace(/-/g, '_');
         const customerNameForFile = customerName.replace(/[^a-zA-Z0-9\u0600-\u06FF]/g, '_');
-        const fileName = `فاتورة_طباعة_${customerNameForFile}_عقود_${contractsList}_${dateFormatted}`;
-        
+        const invoiceTypeText = invoiceType === 'print_only' ? 'طباعة فقط' : invoiceType === 'print_install' ? 'طباعة وتركيب' : 'تركيب فقط';
+        const invoiceTypeCode = invoiceType === 'print_only' ? 'print' : invoiceType === 'print_install' ? 'print_install' : 'install';
+        const fileName = `فاتورة_${invoiceTypeCode}_${customerNameForFile}_عقود_${contractsList}_${dateFormatted}`;
+
         // ✅ إعداد عناصر الجدول مع صفوف ثابتة
         const FIXED_ROWS = 10;
         const displayItems = [...localPrintItems];
@@ -520,7 +523,7 @@ export default function ModernPrintInvoiceDialog({
 
           const html = generateModernPrintInvoiceHTML({
             invoiceNumber,
-            invoiceType: 'فاتورة طباعة',
+            invoiceType: invoiceTypeText,
             invoiceDate,
             customerName,
             items: itemsForGenerator,
@@ -788,7 +791,7 @@ export default function ModernPrintInvoiceDialog({
                 </div>
                 
                 <div class="invoice-info">
-                  <div class="invoice-title">INVOICE</div>
+                  <div class="invoice-title">${invoiceTypeText || 'INVOICE'}</div>
                   <div class="invoice-details">
                     رقم ��لفاتورة: ${invoiceNumber}<br>
                     التاريخ: ${formattedDate}<br>
@@ -951,7 +954,7 @@ export default function ModernPrintInvoiceDialog({
         currency_code: currency?.code || null,
         currency_symbol: currency?.symbol || null,
         include_account_balance: includeAccountBalance ? true : false,
-        invoice_type: 'print',
+        invoice_type: (invoiceType === 'print_only' ? 'print' : invoiceType === 'print_install' ? 'print_install' : 'install'),
         created_at: new Date().toISOString()
       };
 
@@ -996,7 +999,7 @@ export default function ModernPrintInvoiceDialog({
 
       {/* Customer Info */}
       <div className="expenses-preview-item mb-6 p-4 border-r-4 border-primary">
-        <h3 className="expenses-preview-label mb-3 text-lg">بيانات العميل</h3>
+        <h3 className="expenses-preview-label mb-3 text-lg">بيانات ال��ميل</h3>
         <div className="text-sm space-y-1">
           <div><strong>الاسم:</strong> {customerName}</div>
           <div><strong>العقود المرتبط��:</strong> {selectedContracts.join(', ')}</div>
@@ -1175,6 +1178,19 @@ export default function ModernPrintInvoiceDialog({
                             {curr.name} ({curr.symbol})
                           </option>
                         ))}
+                      </select>
+                    </div>
+
+                    <div>
+                      <label className="expenses-form-label mb-2 block text-sm">نوع الفاتورة</label>
+                      <select
+                        value={invoiceType}
+                        onChange={(e) => setInvoiceType(e.target.value as any)}
+                        className="w-full p-3 h-10 border border-border rounded-md text-right bg-input text-foreground text-sm"
+                      >
+                        <option value="print_only">طباعة فقط</option>
+                        <option value="print_install">طباعة وتركيب</option>
+                        <option value="install_only">تركيب فقط</option>
                       </select>
                     </div>
 

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -128,7 +128,7 @@ export default function ModernPrintInvoiceDialog({
   const [sizeOrderMap, setSizeOrderMap] = useState<{ [key: string]: number }>({});
   const [sizeDimensionsMap, setSizeDimensionsMap] = useState<{ [key: string]: { width: number; height: number } }>({});
 
-  // ✅ جلب بيانات الأحجام من قا��دة البيانات مع الأبعاد
+  // ✅ جلب بيانات الأحجام من قا��دة ال��يانات مع الأبعاد
   const fetchSizeData = async () => {
     try {
       const { data: sizesData, error } = await supabase
@@ -465,7 +465,7 @@ export default function ModernPrintInvoiceDialog({
       return;
     }
 
-    // ✅ استخدام نفس تصميم الفاتورة من الكود المرجعي
+    // ✅ استخدام نفس تصميم الفاتور�� من الكود المرجعي
     const printInvoice = async () => {
       try {
         const testWindow = window.open('', '_blank', 'width=1,height=1');
@@ -787,7 +787,8 @@ export default function ModernPrintInvoiceDialog({
                     <th style="width: 12%">أوجه/لوحة</th>
                     <th style="width: 12%">إجمالي الأوجه</th>
                     <th style="width: 18%">الأبعاد (م)</th>
-                    <th style="width: 10%">مساحة الأوجه (م��)</th>
+                    <th style="width: 10%">مساحة الأوجه (م²)</th>
+                    ${!isPrinterCopy ? `<th style="width:12%">سعر المتر (${currency.symbol})</th><th style="width:12%">السعر الإجمالي (${currency.symbol})</th>` : ''}
                   </tr>
                 </thead>
                 <tbody>

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -380,9 +380,9 @@ export default function ModernPrintInvoiceDialog({
       groupedBillboards[groupKey].totalArea += area;
     });
 
-    // ✅ حساب الأسعار الإج��الية وترتيب النتائج
+    // ✅ حساب الأسع��ر الإج��الية وترتيب النتائج
     const result = Object.values(groupedBillboards).map(item => {
-      // ✅ الحساب الصحيح: العرض × الارتفاع × عدد الأوجه × سعر المتر
+      // ✅ الحساب الصحيح: العرض × الارتفاع × عدد ال��وجه × سعر المتر
       const calculatedPrice = item.width * item.height * item.totalFaces * item.pricePerMeter;
       
       console.log(`Processing item ${item.size}: ${item.width} × ${item.height} × ${item.totalFaces} × ${item.pricePerMeter} = ${calculatedPrice}`);
@@ -459,7 +459,7 @@ export default function ModernPrintInvoiceDialog({
     setLocalPrintItems(updatedItems);
   };
 
-  const handlePrint = () => {
+  const handlePrint = (isPrinterCopyParam: boolean = false) => {
     if (localPrintItems.length === 0) {
       toast.error('لا توجد عناصر للطباعة');
       return;
@@ -1168,7 +1168,7 @@ export default function ModernPrintInvoiceDialog({
                           className="text-right text-sm p-3 h-10 bg-muted cursor-not-allowed"
                           title="رقم الفاتورة يتم توليده تلقائياً"
                         />
-                        <p className="text-xs text-muted-foreground mt-1">يتم توليد رقم الفاتورة تلقائياً</p>
+                        <p className="text-xs text-muted-foreground mt-1">يتم توليد ��قم الفاتورة تلقائياً</p>
                       </div>
                       <div>
                         <label className="expenses-form-label mb-2 block text-sm">التاريخ</label>

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -794,6 +794,9 @@ export default function ModernPrintInvoiceDialog({
                 <tbody>
                   ${displayItems.map((item, index) => {
                     const isEmpty = !item.size;
+                    const pricePerMeterVal = Number(item.pricePerMeter) || 0;
+                    const itemTotalPriceVal = Number(item.totalPrice) || ((Number(item.width)||0) * (Number(item.height)||0) * (Number(item.totalFaces)||0) * pricePerMeterVal);
+                    const totalAreaForFaces = (Number(item.area)||0) * (Number(item.totalFaces)||0);
 
                     return `
                       <tr class="${isEmpty ? 'empty-row' : ''}">
@@ -861,7 +864,7 @@ export default function ModernPrintInvoiceDialog({
         // ensure printWindow variable from above or open new window
         printWindow = printWindow || window.open('', '_blank', windowFeatures);
         if (!printWindow) {
-          throw new Error('فشل في فتح نافذة الطباعة. يرجى التحقق من إعدادات المتصفح والسماح بالنوافذ المنبثقة.');
+          throw new Error('فشل في فتح نافذة الطب��عة. يرجى التحقق من إعدادات المتصفح والسماح بالنوافذ المنبثقة.');
         }
 
         // ✅ تعيين عنوان النافذة مع معلومات العميل والعقود والتاريخ

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -501,6 +501,10 @@ export default function ModernPrintInvoiceDialog({
         // If this is a customer copy (not a printer copy), use the centralized HTML generator with prices
         const isPrinterCopy = Boolean(autoPrintForPrinter);
         const moneySubtotal = localPrintItems.reduce((s, it) => s + ((Number(it.width)||0) * (Number(it.height)||0) * (Number(it.totalFaces)||0) * (Number(it.pricePerMeter)||0)), 0);
+
+        const windowFeatures = 'width=1200,height=800,scrollbars=yes,resizable=yes,toolbar=no,menubar=no,location=no,status=no';
+        let printWindow: Window | null = null;
+
         if (!isPrinterCopy) {
           const itemsForGenerator = displayItems.map(it => ({
             size: it.size || '',
@@ -525,6 +529,12 @@ export default function ModernPrintInvoiceDialog({
             printerName: 'web',
             hidePrices: false,
           });
+
+          printWindow = window.open('', '_blank', windowFeatures);
+          if (!printWindow) {
+            toast.error('فشل فتح نافذة الطباعة. يرجى السماح بالنوافذ المنبثقة.');
+            return;
+          }
 
           printWindow.document.open();
           printWindow.document.write(html);
@@ -865,14 +875,13 @@ export default function ModernPrintInvoiceDialog({
           </html>
         `;
 
-        const windowFeatures = 'width=1200,height=800,scrollbars=yes,resizable=yes,toolbar=no,menubar=no,location=no,status=no';
-        const printWindow = window.open('', '_blank', windowFeatures);
-
+        // ensure printWindow variable from above or open new window
+        printWindow = printWindow || window.open('', '_blank', windowFeatures);
         if (!printWindow) {
           throw new Error('فشل في فتح نافذة الطباعة. يرجى التحقق من إعدادات المتصفح والسماح بالنوافذ المنبثقة.');
         }
 
-        // ✅ تعي��ن عنوان النافذة مع معلومات العميل والعقود والتاريخ
+        // ✅ تعيين عنوان النافذة مع معلومات العميل والعقود والتاريخ
         printWindow.document.title = fileName;
 
         printWindow.document.open();

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -513,43 +513,7 @@ export default function ModernPrintInvoiceDialog({
         const windowFeatures = 'width=1200,height=800,scrollbars=yes,resizable=yes,toolbar=no,menubar=no,location=no,status=no';
         let printWindow: Window | null = null;
 
-        if (!isPrinterCopy) {
-          const itemsForGenerator = displayItems.map(it => ({
-            size: it.size || '',
-            quantity: it.quantity || 0,
-            faces: it.faces || 0,
-            totalFaces: it.totalFaces || 0,
-            width: it.width || 0,
-            height: it.height || 0,
-            area: it.area || 0,
-            pricePerMeter: it.pricePerMeter || 0,
-            totalPrice: it.totalPrice || 0,
-          }));
-
-          const html = generateModernPrintInvoiceHTML({
-            invoiceNumber,
-            invoiceType: invoiceTypeText,
-            invoiceDate,
-            customerName,
-            items: itemsForGenerator,
-            totalAmount: moneySubtotal,
-            notes,
-            printerName: 'web',
-            hidePrices: false,
-          });
-
-          printWindow = window.open('', '_blank', windowFeatures);
-          if (!printWindow) {
-            toast.error('فشل فتح نافذة الطباعة. يرجى السماح بالنوافذ المنبثقة.');
-            return;
-          }
-
-          printWindow.document.open();
-          printWindow.document.write(html);
-          printWindow.document.close();
-          toast.success(`تم فتح الفاتورة للطباعة بنجاح بعم��ة ${currency.name}!`);
-          return;
-        }
+        const tableHeaderExtra = isPrinterCopy ? '' : `<th style="width: 12%">سعر المتر</th><th style="width: 12%">السعر الإجمالي</th>`;
 
         const htmlContent = `
           <!DOCTYPE html>

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -96,6 +96,7 @@ const formatArabicNumber = (num: number): string => {
 export default function ModernPrintInvoiceDialog({
   open,
   onClose,
+  customerId,
   customerName,
   contracts,
   selectedContracts,
@@ -107,7 +108,11 @@ export default function ModernPrintInvoiceDialog({
   onIncludeAccountBalance,
   accountPayments,
   onPrintInvoice,
-  onSaveInvoice
+  onSaveInvoice,
+  initialInvoice,
+  openToPreview,
+  autoPrint,
+  autoPrintForPrinter
 }: ModernPrintInvoiceDialogProps) {
   const [activeTab, setActiveTab] = useState<'setup' | 'preview'>('setup');
   const [currency, setCurrency] = useState(CURRENCIES[0]);
@@ -744,7 +749,7 @@ export default function ModernPrintInvoiceDialog({
                 <div class="customer-details">
                   <strong>الاسم:</strong> ${customerName}<br>
                   <strong>العقود المرتبطة:</strong> ${selectedContracts.join(', ')}<br>
-                  <strong>تاريخ الفاتورة:</strong> ${formattedDate}
+                  <strong>��اريخ الفاتورة:</strong> ${formattedDate}
                 </div>
               </div>
               
@@ -846,7 +851,7 @@ export default function ModernPrintInvoiceDialog({
         printWindow.document.write(htmlContent);
         printWindow.document.close();
 
-        toast.success(`تم فتح الفاتورة للطباعة بنجاح بعملة ${currency.name}!`);
+        toast.success(`تم فتح الفاتورة للطباع�� بنجاح بعملة ${currency.name}!`);
 
       } catch (error) {
         console.error('Error in print invoice:', error);
@@ -977,7 +982,7 @@ export default function ModernPrintInvoiceDialog({
               
               {discount > 0 && (
                 <div className="flex justify-between py-2 text-sm text-green-400">
-                  <span>خصم ({discountType === 'percentage' ? `${discount}%` : `${formatArabicNumber(discount)} ${currency.symbol}`}):</span>
+                  <span>خص�� ({discountType === 'percentage' ? `${discount}%` : `${formatArabicNumber(discount)} ${currency.symbol}`}):</span>
                   <span className="font-bold">- {formatArabicNumber(discountAmount)} {currency.symbol}</span>
                 </div>
               )}

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -49,6 +49,7 @@ interface ContractRow {
 interface ModernPrintInvoiceDialogProps {
   open: boolean;
   onClose: () => void;
+  customerId?: string | null;
   customerName: string;
   contracts: ContractRow[];
   selectedContracts: string[];
@@ -61,6 +62,11 @@ interface ModernPrintInvoiceDialogProps {
   accountPayments: number;
   onPrintInvoice: () => void;
   onSaveInvoice: () => void;
+  // New props for loading/saving existing invoices and auto-printing
+  initialInvoice?: any | null;
+  openToPreview?: boolean;
+  autoPrint?: boolean;
+  autoPrintForPrinter?: boolean;
 }
 
 const CURRENCIES = [
@@ -275,7 +281,7 @@ export default function ModernPrintInvoiceDialog({
       const size = String(billboard.Size ?? billboard.size ?? 'غير محدد');
       const faces = Number(billboard.Faces ?? billboard.faces ?? billboard.Number_of_Faces ?? billboard.Faces_Count ?? billboard.faces_count ?? 1);
       
-      // ✅ جلب الأبعاد من قاعدة البيانات
+      // ✅ جلب الأبعاد م�� قاعدة البيانات
       const dimensions = sizeDimensionsMap[size];
       const width = dimensions?.width || 0;
       const height = dimensions?.height || 0;
@@ -675,7 +681,7 @@ export default function ModernPrintInvoiceDialog({
                 <div class="invoice-info">
                   <div class="invoice-title">INVOICE</div>
                   <div class="invoice-details">
-                    رقم الفاتورة: ${invoiceNumber}<br>
+                    رقم ال��اتورة: ${invoiceNumber}<br>
                     التاريخ: ${formattedDate}<br>
                     العملة: ${currency.name}
                   </div>
@@ -1185,7 +1191,7 @@ export default function ModernPrintInvoiceDialog({
                                 />
                               </div>
                               <div>
-                                <label className="block text-xs text-muted-foreground mb-2">سعر المتر</label>
+                                <label className="block text-xs text-muted-foreground mb-2">سعر ا��متر</label>
                                 <Input
                                   type="number"
                                   value={item.pricePerMeter}

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -472,7 +472,7 @@ export default function ModernPrintInvoiceDialog({
         const currentDate = new Date(invoiceDate);
         const formattedDate = currentDate.toLocaleDateString('ar-LY');
         
-        // ✅ إنشاء اسم الملف مع معلومات العميل والعقود والتاريخ
+        // ✅ إنشاء اسم الملف مع معلومات العميل و��لعقود والتاريخ
         const contractsList = selectedContracts.join('-');
         const dateFormatted = currentDate.toISOString().slice(0, 10).replace(/-/g, '_');
         const customerNameForFile = customerName.replace(/[^a-zA-Z0-9\u0600-\u06FF]/g, '_');
@@ -764,20 +764,18 @@ export default function ModernPrintInvoiceDialog({
                 <thead>
                   <tr>
                     <th style="width: 6%">#</th>
-                    <th style="width: 24%">المقاس</th>
-                    <th style="width: 8%">عدد اللوحات</th>
-                    <th style="width: 8%">أوجه/لوحة</th>
-                    <th style="width: 8%">إجمالي الأوجه</th>
-                    <th style="width: 10%">الأبعاد (م)</th>
+                    <th style="width: 30%">المقاس</th>
+                    <th style="width: 12%">عدد اللوحات</th>
+                    <th style="width: 12%">أوجه/لوحة</th>
+                    <th style="width: 12%">إجمالي الأوجه</th>
+                    <th style="width: 18%">الأبعاد (م)</th>
                     <th style="width: 10%">مساحة الأوجه (م²)</th>
-                    <th style="width: 10%">سعر المتر</th>
-                    <th style="width: 16%">إجمالي السعر</th>
                   </tr>
                 </thead>
                 <tbody>
                   ${displayItems.map((item, index) => {
                     const isEmpty = !item.size;
-                    
+
                     return `
                       <tr class="${isEmpty ? 'empty-row' : ''}">
                         <td>${isEmpty ? '' : index + 1}</td>
@@ -789,40 +787,27 @@ export default function ModernPrintInvoiceDialog({
                         <td>${isEmpty ? '' : (typeof item.totalFaces === 'number' ? formatArabicNumber(item.totalFaces) : item.totalFaces)}</td>
                         <td>${isEmpty ? '' : (typeof item.width === 'number' && typeof item.height === 'number' ? `${item.width} × ${item.height}` : '')}</td>
                         <td>${isEmpty ? '' : (typeof item.area === 'number' && typeof item.totalFaces === 'number' ? `${(item.area * item.totalFaces).toFixed(2)} م²` : item.area)}</td>
-                        <td>${isEmpty ? '' : (typeof item.pricePerMeter === 'number' ? `${formatArabicNumber(item.pricePerMeter)} ${currency.symbol}` : item.pricePerMeter)}</td>
-                        <td>${isEmpty ? '' : (typeof item.totalPrice === 'number' ? `${formatArabicNumber(item.totalPrice)} ${currency.symbol}` : item.totalPrice)}</td>
                       </tr>
                     `;
                   }).join('')}
                 </tbody>
               </table>
-              
+
               <div class="total-section">
                 ${discount > 0 ? `
                   <div class="total-row subtotal">
-                    <span>المجموع الفرعي:</span>
-                    <span>${formatArabicNumber(subtotal)} ${currency.symbol}</span>
+                    <span>إجمالي الأوجه:</span>
+                    <span>${formatArabicNumber(subtotal)} وحدة</span>
                   </div>
                   <div class="total-row discount">
-                    <span>خصم (${discountType === 'percentage' ? `${discount}%` : `${formatArabicNumber(discount)} ${currency.symbol}`}):</span>
-                    <span>- ${formatArabicNumber(discountAmount)} ${currency.symbol}</span>
+                    <span>خصم (${discountType === 'percentage' ? `${discount}%` : `${formatArabicNumber(discount)} وحدة`}):</span>
+                    <span>- ${formatArabicNumber(discountAmount)} وحدة</span>
                   </div>
                 ` : ''}
-                
-                ${includeAccountBalance && accountPayments > 0 ? `
-                  <div class="total-row discount">
-                    <span>رصيد الحساب:</span>
-                    <span>- ${formatArabicNumber(accountPayments)} ${currency.symbol}</span>
-                  </div>
-                ` : ''}
-                
+
                 <div class="total-row grand-total">
-                  <span>المجموع الإجمالي:</span>
-                  <span class="currency">${formatArabicNumber(total)} ${currency.symbol}</span>
-                </div>
-                
-                <div style="margin-top: 15px; font-size: 13px; color: #666; text-align: center;">
-                  المبلغ بالكلمات: ${formatArabicNumber(total)} ${currency.writtenName}
+                  <span>العدد النهائي للأوجه:</span>
+                  <span class="currency">${formatArabicNumber(total)} وحدة</span>
                 </div>
               </div>
               
@@ -969,7 +954,7 @@ export default function ModernPrintInvoiceDialog({
         <h3 className="expenses-preview-label mb-3 text-lg">بيانات العميل</h3>
         <div className="text-sm space-y-1">
           <div><strong>الاسم:</strong> {customerName}</div>
-          <div><strong>العقود المرتبطة:</strong> {selectedContracts.join(', ')}</div>
+          <div><strong>العقود المرتبط��:</strong> {selectedContracts.join(', ')}</div>
           <div><strong>تاريخ الفاتورة:</strong> {new Date(invoiceDate).toLocaleDateString('ar-LY')}</div>
         </div>
       </div>

--- a/src/components/billing/ModernPrintInvoiceDialog.tsx
+++ b/src/components/billing/ModernPrintInvoiceDialog.tsx
@@ -1000,19 +1000,27 @@ export default function ModernPrintInvoiceDialog({
                   <th className="border border-border p-3 text-center font-bold">إجمالي الأوجه</th>
                   <th className="border border-border p-3 text-center font-bold">الأبعاد (م)</th>
                   <th className="border border-border p-3 text-center font-bold">المساحة/الوجه</th>
+                  <th className="border border-border p-3 text-center font-bold">سعر المتر ({currency.symbol})</th>
+                  <th className="border border-border p-3 text-center font-bold">الإجمالي ({currency.symbol})</th>
                 </tr>
               </thead>
               <tbody>
-                {localPrintItems.map((item, index) => (
-                  <tr key={index} className={index % 2 === 0 ? 'bg-card/50' : 'bg-background'}>
-                    <td className="border border-border p-3 text-center font-medium">{item.size}</td>
-                    <td className="border border-border p-3 text-center">{formatArabicNumber(item.quantity)}</td>
-                    <td className="border border-border p-3 text-center">{formatArabicNumber(item.faces)}</td>
-                    <td className="border border-border p-3 text-center font-medium">{formatArabicNumber(item.totalFaces)}</td>
-                    <td className="border border-border p-3 text-center">{item.width} × {item.height}</td>
-                    <td className="border border-border p-3 text-center">{item.area.toFixed(2)} م²</td>
-                  </tr>
-                ))}
+                {localPrintItems.map((item, index) => {
+                  const pricePerMeterVal = Number(item.pricePerMeter) || 0;
+                  const itemTotalPriceVal = Number(item.totalPrice) || ((Number(item.width) || 0) * (Number(item.height) || 0) * (Number(item.totalFaces) || 0) * pricePerMeterVal);
+                  return (
+                    <tr key={index} className={index % 2 === 0 ? 'bg-card/50' : 'bg-background'}>
+                      <td className="border border-border p-3 text-center font-medium">{item.size}</td>
+                      <td className="border border-border p-3 text-center">{formatArabicNumber(item.quantity)}</td>
+                      <td className="border border-border p-3 text-center">{formatArabicNumber(item.faces)}</td>
+                      <td className="border border-border p-3 text-center font-medium">{formatArabicNumber(item.totalFaces)}</td>
+                      <td className="border border-border p-3 text-center">{item.width} × {item.height}</td>
+                      <td className="border border-border p-3 text-center">{(Number(item.area) || 0).toFixed(2)} م²</td>
+                      <td className="border border-border p-3 text-center">{formatArabicNumber(pricePerMeterVal)} {currency.symbol}</td>
+                      <td className="border border-border p-3 text-center font-medium">{formatArabicNumber(itemTotalPriceVal)} {currency.symbol}</td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>

--- a/src/components/contracts/edit/ContractEditModular.tsx
+++ b/src/components/contracts/edit/ContractEditModular.tsx
@@ -6,7 +6,7 @@ import { loadBillboards } from '@/services/billboardService';
 import { addBillboardsToContract, getContractWithBillboards, removeBillboardFromContract, updateContract } from '@/services/contractService';
 import { calculateInstallationCostFromIds } from '@/services/installationService';
 import { getPriceFor, getDailyPriceFor, CustomerType } from '@/data/pricing';
-import { ContractPDFDialog } from '@/components/contract';
+import { ContractPDFDialog } from '@/components/Contract';
 import type { Billboard } from '@/types';
 
 // Import modular components
@@ -451,7 +451,7 @@ export default function ContractEditModular() {
           amount: half, 
           paymentType: 'عند التوقيع', 
           description: 'الدفعة الأولى',
-          dueDate: calculateDueDate('عند التوقيع', 0)
+          dueDate: calculateDueDate('عند ال��وقيع', 0)
         },
         { 
           amount: finalTotal - half, 

--- a/src/pages/ContractEdit.tsx
+++ b/src/pages/ContractEdit.tsx
@@ -6,7 +6,7 @@ import { loadBillboards } from '@/services/billboardService';
 import { addBillboardsToContract, getContractWithBillboards, removeBillboardFromContract, updateContract } from '@/services/contractService';
 import { calculateInstallationCostFromIds } from '@/services/installationService';
 import { getPriceFor, getDailyPriceFor, CustomerType } from '@/data/pricing';
-import { ContractPDFDialog } from '@/components/contract';
+import { ContractPDFDialog } from '@/components/Contract';
 import type { Billboard } from '@/types';
 import { Button } from '@/components/ui/button';
 import { RefreshCw, DollarSign, Settings, Wrench } from 'lucide-react';

--- a/src/src/components/contracts/edit/ContractEditModular.tsx
+++ b/src/src/components/contracts/edit/ContractEditModular.tsx
@@ -6,7 +6,7 @@ import { loadBillboards } from '@/services/billboardService';
 import { addBillboardsToContract, getContractWithBillboards, removeBillboardFromContract, updateContract } from '@/services/contractService';
 import { calculateInstallationCostFromIds } from '@/services/installationService';
 import { getPriceFor, getDailyPriceFor, CustomerType } from '@/data/pricing';
-import { ContractPDFDialog } from '@/components/contract';
+import { ContractPDFDialog } from '@/components/Contract';
 import type { Billboard } from '@/types';
 
 // Import modular components
@@ -363,7 +363,7 @@ export default function ContractEditModular() {
       date.setMonth(date.getMonth() + (index + 1));
     } else if (paymentType === 'شهرين') {
       date.setMonth(date.getMonth() + (index + 1) * 2);
-    } else if (paymentType === 'ثلاثة أشهر') {
+    } else if (paymentType === 'ث��اثة أشهر') {
       date.setMonth(date.getMonth() + (index + 1) * 3);
     } else if (paymentType === 'عند التركيب') {
       date.setDate(date.getDate() + 7);

--- a/src/src/pages/ContractEdit.tsx
+++ b/src/src/pages/ContractEdit.tsx
@@ -6,7 +6,7 @@ import { loadBillboards } from '@/services/billboardService';
 import { addBillboardsToContract, getContractWithBillboards, removeBillboardFromContract, updateContract } from '@/services/contractService';
 import { calculateInstallationCostFromIds } from '@/services/installationService';
 import { getPriceFor, getDailyPriceFor, CustomerType } from '@/data/pricing';
-import { ContractPDFDialog } from '@/components/contract';
+import { ContractPDFDialog } from '@/components/Contract';
 import type { Billboard } from '@/types';
 import { Button } from '@/components/ui/button';
 import { RefreshCw, DollarSign, Settings, Wrench } from 'lucide-react';
@@ -799,7 +799,7 @@ export default function ContractEdit() {
           amount: half, 
           paymentType: 'عند التوقيع', 
           description: 'الدفعة الأولى',
-          dueDate: calculateDueDate('عند التوقيع', 0)
+          dueDate: calculateDueDate('عند التوق��ع', 0)
         },
         { 
           amount: finalTotal - half, 

--- a/src/src/pages/CustomerBilling.tsx
+++ b/src/src/pages/CustomerBilling.tsx
@@ -481,8 +481,8 @@ export default function CustomerBilling() {
   };
 
   const printPrintingInvoicePage = async () => {
-    const printTotal = printItems.reduce((sum, item) => sum + item.totalPrice, 0);
-    
+    const totalFaces = printItems.reduce((s, item) => s + (Number(item.totalFaces) || 0), 0);
+
     const printRows = printItems.map(item => `
       <tr>
         <td>${item.size}</td>
@@ -491,8 +491,6 @@ export default function CustomerBilling() {
         <td>${item.totalFaces}</td>
         <td>${item.area.toFixed(2)} م²</td>
         <td>${item.totalArea.toFixed(2)} م²</td>
-        <td>${item.pricePerMeter.toLocaleString('ar-LY')} د.ل</td>
-        <td>${item.totalPrice.toLocaleString('ar-LY')} د.ل</td>
       </tr>
     `).join('');
 
@@ -517,9 +515,9 @@ export default function CustomerBilling() {
         .signature-line{border-top:2px solid #374151;margin-top:40px;padding-top:10px}
         @media print{body{background:white!important;color:black!important;padding:10px} .customer-info,table{background:white!important} th{background:#f5f5f5!important;color:black!important} .total-row{background:#fff7ed!important;color:#92400e!important} @page{size:A4;margin:10mm}}
       </style></head><body>
-      
+
       <h1>فاتورة طباعة</h1>
-      
+
       <div class="customer-info">
         <div class="info-row">
           <span class="info-label">العميل:</span>
@@ -534,7 +532,7 @@ export default function CustomerBilling() {
           <span class="info-value">${selectedContractsForInv.join(', ')}</span>
         </div>
       </div>
-      
+
       <div class="section-title">تفاصيل الطباعة:</div>
       <table>
         <thead>
@@ -545,15 +543,13 @@ export default function CustomerBilling() {
             <th>إجمالي الأوجه</th>
             <th>المساحة/الوحدة</th>
             <th>إجمالي المساحة</th>
-            <th>سعر المتر</th>
-            <th>إجمالي السعر</th>
           </tr>
         </thead>
         <tbody>
           ${printRows}
           <tr class="total-row">
-            <td colspan="7">الإجمالي النهائي</td>
-            <td>${printTotal.toLocaleString('ar-LY')} د.ل</td>
+            <td colspan="5">الإجمالي النهائي (أوجه)</td>
+            <td>${totalFaces.toLocaleString('ar-LY')} وحدة</td>
           </tr>
         </tbody>
       </table>
@@ -618,7 +614,7 @@ export default function CustomerBilling() {
         return; 
       }
 
-      toast.success('تم حفظ فاتورة الطباعة في حساب العميل');
+      toast.success('تم حفظ فات��رة الطباعة في حساب العميل');
       setPrintContractInvoiceOpen(false);
       
       setSelectedContractsForInv([]);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    hmr: { overlay: false },
   },
   plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
   optimizeDeps: {


### PR DESCRIPTION
## Purpose

Based on the conversation history, the user requested modifications to the invoice printing functionality:
- Keep the invoice format the same as before, only modify columns
- Add total column and price per meter column
- Fix printing issues where price per meter, total, and area columns weren't showing
- Change "الوجه" (face) to "مساحة اجمالي الاوجه" (total faces area)
- For printer version: remove total price, only show total faces

## Code changes

- **Invoice Templates**: Modified `generateModernPrintInvoiceHTML` to conditionally hide price columns (`سعر المتر` and `إجمالي السعر`) in printer version while keeping total faces display
- **Print Dialog**: Added separate print buttons for "مع الأسعار" (with prices) and "للطابعة (أوجه فقط)" (printer version - faces only)
- **Customer Billing**: Updated print invoice logic to show only total faces instead of total price in printer version
- **Data Loading**: Enhanced invoice loading to support multiple data source fields (`print_items`, `print_items_json`, `items`, `items_json`)
- **Import Fixes**: Corrected import paths for `ContractPDFDialog` component
- **Development**: Added HMR overlay disable for better development experience

The changes ensure that the regular invoice shows all columns including prices, while the printer version only displays face totals without pricing information.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/4b42dc83d7ad4950a71cf72a1e0ddd59/pixel-works)

👀 [Preview Link](https://4b42dc83d7ad4950a71cf72a1e0ddd59-pixel-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4b42dc83d7ad4950a71cf72a1e0ddd59</projectId>-->
<!--<branchName>pixel-works</branchName>-->